### PR TITLE
Landing update

### DIFF
--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
+<title>{% if page.title %}{{ page.title | escape }} {% else %}{{ site.title | escape }}{% endif %}</title>
 <meta name="description" content="{% if page.description %}{{ page.description | escape }}{% else %}{{ site.description | escape }}{% endif %}">
 <meta name="keywords" content="{% if page.topics %}{{ page.topics | escape }}{% else %}{{ site.keywords | escape }}{% endif %}">
 <meta name="author" content="{{ site.author | escape }}">

--- a/index.md
+++ b/index.md
@@ -3,8 +3,6 @@ title: ICSE '24 workshop on IDEs
 layout: page
 ---
 
-# Welcome!
-
 {% include figure.html img="title.jpg" alt="title card" width="100%" %}
 
 ## Call for submissions

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: ICSE '24 workshop on IDEs
 layout: page
 ---
 


### PR DESCRIPTION
 * better title for page preview on unfurl (this should also work when we move it to an archive `2024.md`)
 * remove 'Welcome' title 